### PR TITLE
Add 4-bit quantized TinyLlama: `TheBloke/TinyLlama-1.1B-Chat-v1.0-AWQ`

### DIFF
--- a/examples/llm-streaming-chat/models/chat.py
+++ b/examples/llm-streaming-chat/models/chat.py
@@ -42,6 +42,10 @@ class StreamingChat:
             model_name="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
             compute_dtype="bfloat16",
         ),
+        "TheBloke/TinyLlama-1.1B-Chat-v1.0-AWQ": StreamingChatConfig(
+            model_name="TheBloke/TinyLlama-1.1B-Chat-v1.0-AWQ",
+            additional_kwargs={"low_cpu_mem_usage": True},
+        ),
         "TheBloke/Mixtral-8x7B-Instruct-v0.1-AWQ": StreamingChatConfig(
             model_name="TheBloke/Mixtral-8x7B-Instruct-v0.1-AWQ",
             additional_kwargs={"low_cpu_mem_usage": True},

--- a/examples/llm-streaming-chat/serve.yaml
+++ b/examples/llm-streaming-chat/serve.yaml
@@ -1,26 +1,19 @@
 images:
-  llm-gpu:
-    base: autonomi/nos:latest-gpu
+  llm-py310-cu121:
+    base: autonomi/nos:latest-py310-cu121
     pip:
-      - autoawq
-      - accelerate>=0.23.0
+      - git+https://github.com/casper-hansen/AutoAWQ
       - bitsandbytes
-      - sentencepiece>=0.1.99
-      - ninja==1.11.1
-      - git+https://github.com/huggingface/transformers.git
-    env:
-      NOS_LOGGING_LEVEL: DEBUG
-      NOS_MAX_CONCURRENT_MODELS: 2
 
 models:
-  TinyLlama/TinyLlama-1.1B-Chat-v1.0:
+  TheBloke/TinyLlama-1.1B-Chat-v1.0-AWQ:
     model_cls: StreamingChat
     model_path: models/chat.py
     init_kwargs:
-      model_name: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+      model_name: TheBloke/TinyLlama-1.1B-Chat-v1.0-AWQ
     default_method: chat
     runtime_env: llm-gpu
     deployment:
       resources:
         device: auto
-        device_memory: 2.5Gi
+        device_memory: 3Gi

--- a/examples/llm-streaming-chat/tests/test_chat.py
+++ b/examples/llm-streaming-chat/tests/test_chat.py
@@ -15,8 +15,9 @@ def client():
 
 SYSTEM_PROMPT = "You are NOS chat, a Llama 2 large language model (LLM) agent hosted by Autonomi AI."
 MODELS = [
-    "meta-llama/Llama-2-7b-chat-hf",
-    "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    # "meta-llama/Llama-2-7b-chat-hf",
+    # "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "TheBloke/TinyLlama-1.1B-Chat-v1.0-AWQ",
 ]
 
 


### PR DESCRIPTION
Low memory footprint chatbot with 1.1B parameters with 4-bit quantization.
```bash
StreamingChat:chat:124 - tok/s=41.28, memory=778.95 MB, allocated=782.86 MB, peak=818.00 MB
```